### PR TITLE
add libsodium-dev to package list

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -535,6 +535,7 @@ libsnappy1v5
 libsndfile1
 libsndio6.1
 libsndio-dev
+libsodium-dev
 libsoup2.4-1
 libsoup2.4-dev
 libsoup-gnome2.4-1


### PR DESCRIPTION
The crate `libsodium-sys` depends on having the libsodium headers available.