### PR TITLE
Build and publish Windows image on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+
+platform:
+    - x86
+
+environment:
+    PUSH_IMAGE: 'rustops/crates-build-env-windows'
+
+# If Docker is currently configured to run Linux containers, we need to switch
+# to running Windows containers.
+#
+# https://github.com/docker/cli/issues/1042
+init:
+    # - ps: $env:ProgramFiles/Docker/Docker/DockerCli.exe -SwitchDaemon
+
+build_script:
+    - ps: ./windows/ci/build.ps1
+
+deploy_script:
+    - ps: ./windows/ci/publish.ps1
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,5 +18,5 @@ build_script:
     - ps: ./windows/ci/build.ps1
 
 deploy_script:
-    - ps: ./windows/ci/publish.ps1
+    - ps: if ($env:APPVEYOR_REPO_BRANCH -eq "master") { ./windows/ci/publish.ps1 }
 

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,6 +1,8 @@
 # escape=`
 
-FROM mcr.microsoft.com/windows/servercore:1803
+ARG BASE_IMAGE_VER=:1803
+
+FROM mcr.microsoft.com/windows/servercore${BASE_IMAGE_VER}
 
 # Install the Visual C++ Build tools
 #

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,9 +1,8 @@
 # Windows build environment for rust crates
 
 This repository contains the source of a Docker container the Rust project uses
-to build third-party crates on Windows. It is based on **Windows Server Core,
-version 1803**, and contains all the native dependencies used by the Rust
-crates we know of.
+to build third-party crates on Windows. It is based on **Windows Server Core**,
+and contains all the native dependencies used by the Rust crates we know of.
 
 ## Dependencies
 
@@ -16,6 +15,10 @@ This image must be run on a Windows host with both containerization and Hyper-V
 enabled (Windows 10 Pro or Windows Server >=2016). If you wish to run `crater`
 on an Azure VM, this requires a virtual machine image tagged with "v3".
 
+The version of the base image can be configured by passing `--build-arg
+BASE_IMAGE_VER=${YOUR_DESIRED_VERSION_NUMBER}` to `docker build`. It defaults
+to `:1803` (note the leading colon) which specifies Windows Server Core,
+version 1803.
 
 Hyper-V can be enabled in [the GUI][hyperv] or in `Powershell` with:
 
@@ -29,7 +32,7 @@ A reboot is required for this to take effect.
 
 
 The Docker host must have a [build number][build] equal to that of the image
-you wish to run (presently `mcr.microsoft.com/windows/servercore:1803`).
+you wish to run (by default `mcr.microsoft.com/windows/servercore:1803`).
 
 [Docker Desktop][] is required to run native Windows containers; this image
 will not work with Docker Toolbox. Once installed, ensure that Docker Desktop

--- a/windows/ci/build.ps1
+++ b/windows/ci/build.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop"
+
+$ContainerBase = '@sha256:c06b4bfaf634215ea194e6005450740f3a230b27c510cf8facab1e9c678f3a99'
+
+docker build                                    `
+    -t "$env:PUSH_IMAGE"                        `
+    --build-arg "BASE_IMAGE_VER=$ContainerBase" `
+    windows

--- a/windows/ci/publish.ps1
+++ b/windows/ci/publish.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = "Stop"
+
+# Build the image
+./windows/ci/build.ps1
+
+# Log in to dockerhub
+[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Env:DOCKER_PASSWORD)).Trim() `
+    | docker login --username "$Env:DOCKER_USERNAME" --password-stdin
+
+docker push "$env:PUSH_IMAGE"


### PR DESCRIPTION
This builds and publishes the Windows image added in #5 on AppVeyor. As with the Travis CI integration, `DOCKER_{PASSWORD,USERNAME}` must be set as environment variables.