### PR TITLE
Ensure "DOCKER_{PASSWORD,USERNAME}" are set prior to deployment on AppVeyor

### DIFF
--- a/windows/ci/publish.ps1
+++ b/windows/ci/publish.ps1
@@ -3,6 +3,13 @@ $ErrorActionPreference = "Stop"
 # Build the image
 ./windows/ci/build.ps1
 
+foreach ($var in "DOCKER_USERNAME", "DOCKER_PASSWORD") {
+    if (-not (Test-Path "env:$var")) {
+        echo "Environment variable \"$var\" not set"
+        exit 22
+    }
+}
+
 # Log in to dockerhub
 [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Env:DOCKER_PASSWORD)).Trim() `
     | docker login --username "$Env:DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
The AppVeyor `publish.ps` script [will fail cryptically](https://ci.appveyor.com/project/rust-lang-libs/crates-build-env/builds/22510785) if `DOCKER_USERNAME` is not set.