### PR TITLE
Make libraries installed by `vcpkg` usable by crates.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ variables:
 
 jobs:
 - job: Windows
+  timeoutInMinutes: 0
   pool:
     vmImage: win1803
   variables:

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -21,12 +21,21 @@ SHELL ["powershell", "-Command"]
 ADD https://github.com/Microsoft/vcpkg/archive/master.zip C:\TEMP\vcpkg-master.zip
 RUN $ErrorActionPreference = 'Stop';                                  `
     Expand-Archive -Path C:\TEMP\vcpkg-master.zip -DestinationPath .; `
+    rm C:\TEMP\vcpkg-master.zip;                                      `
     cd .\vcpkg-master;                                                `
     .\bootstrap-vcpkg.bat;                                            `
     .\vcpkg integrate install
 
 # Install packages
+#
+# The `vcpkg` crate searches for libraries matching the target architecture
+# exactly. It won't use x86 libraries on a 64-bit system. Setting the default
+# triplet tells `vcpkg` to install 64-bit versions.
+ENV VCPKG_DEFAULT_TRIPLET=x64-windows
 COPY vc-packages.txt C:\
 RUN .\vcpkg-master\vcpkg install @(Get-Content C:\vc-packages.txt)
+
+# Tell the `vcpkg` crate to generate dynamically linked executables
+ENV VCPKGRS_DYNAMIC=1
 
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -15,7 +15,22 @@ RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
     --includeRecommended                                           `
     || IF "%ERRORLEVEL%"=="3010" EXIT 0
 
-SHELL ["powershell", "-Command"]
+SHELL ["powershell", "-ExecutionPolicy", "Bypass", "-Command"]
+
+# Install chocolatey
+RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+# Install packages
+#
+# We need to get the new value of `$PATH` after `choco install`, but
+# chocolatey's `refreshenv` won't be available until we restart the shell.
+# Make `refreshenv` available right away, by importing the Chocolatey profile
+# module. See https://stackoverflow.com/a/46760714.
+COPY choco-packages.txt C:\
+RUN $ErrorActionPreference = 'Stop';                                           `
+    choco install -y @(Get-Content C:\choco-packages.txt);                     `
+    Import-Module "C:\ProgramData\chocolatey\helpers\chocolateyProfile.psm1";  `
+    refreshenv
 
 # Install vcpkg
 ADD https://github.com/Microsoft/vcpkg/archive/master.zip C:\TEMP\vcpkg-master.zip
@@ -26,7 +41,7 @@ RUN $ErrorActionPreference = 'Stop';                                  `
     .\bootstrap-vcpkg.bat;                                            `
     .\vcpkg integrate install
 
-# Install packages
+# Install C libraries
 #
 # The `vcpkg` crate searches for libraries matching the target architecture
 # exactly. It won't use x86 libraries on a 64-bit system. Setting the default

--- a/windows/choco-packages.txt
+++ b/windows/choco-packages.txt
@@ -1,0 +1,5 @@
+cmake
+--installargs='ADD_CMAKE_TO_PATH=System'
+git
+mingw
+ninja

--- a/windows/choco-packages.txt
+++ b/windows/choco-packages.txt
@@ -3,3 +3,5 @@ cmake
 git
 mingw
 ninja
+netfx-4.6.1-devpack
+llvm

--- a/windows/choco-packages.txt
+++ b/windows/choco-packages.txt
@@ -1,7 +1,7 @@
 cmake
 --installargs='ADD_CMAKE_TO_PATH=System'
 git
-mingw
-ninja
-netfx-4.6.1-devpack
 llvm
+mingw
+netfx-4.6.1-devpack
+ninja

--- a/windows/vc-packages.txt
+++ b/windows/vc-packages.txt
@@ -1,5 +1,4 @@
 curl
-libmysql
 libpq
 libsodium
 libssh2

--- a/windows/vc-packages.txt
+++ b/windows/vc-packages.txt
@@ -2,6 +2,9 @@ curl
 libpq
 libsodium
 libssh2
+openal-soft
 openssl
+portmidi
+sdl2
 sqlite3
 zlib

--- a/windows/vc-packages.txt
+++ b/windows/vc-packages.txt
@@ -1,1 +1,8 @@
+curl
+libmysql
+libpq
+libsodium
+libssh2
+openssl
+sqlite3
 zlib


### PR DESCRIPTION
This sets the necessary environment variables for the [`vcpkg`](https://crates.io/crates/vcpkg) crate to dynamically link to packages installed by the [`vcpkg`](https://github.com/microsoft/vcpkg) package manager.

This also adds the underlying libraries for the [reverse dependencies of the `vcpkg` crate](https://crates.io/crates/vcpkg/reverse_dependencies) to `vc-packages.txt`.

Addresses #9.