### PR TITLE
Install pkg-config

### DIFF
--- a/windows/choco-packages.txt
+++ b/windows/choco-packages.txt
@@ -5,3 +5,4 @@ llvm
 mingw
 netfx-4.6.1-devpack
 ninja
+pkgconfiglite


### PR DESCRIPTION
`choco` includes a version of `pkg-config` for Windows which doesn't depend on `glib`. Use it for building crates which depend on `pkg-config` like `libusb-sys` and `curl-sys`.