### PR TITLE
Add more libraries

### DIFF
--- a/windows/vc-packages.txt
+++ b/windows/vc-packages.txt
@@ -1,10 +1,14 @@
 curl
+freetype
 libpq
 libsodium
 libssh2
+libusb
 openal-soft
 openssl
+portaudio
 portmidi
 sdl2
+sdl2-image
 sqlite3
 zlib


### PR DESCRIPTION
Addresses #9 by installing the following libraries:

- `SDL2-image` (required by `ruscur.phase`)
- `freetype` (required by `jjjjw.rust_elmish_rocket`)
- `libusb` (required by `libusb-sys`)
- `portaudio` (required by `weresocool-0.1.0`)