### PR TITLE
Add qt3d5-dev, qtcharts5-dev, qttools5-dev, qt5-default to packages.txt

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -659,6 +659,7 @@ libpython3-stdlib
 libpython-dev
 libpython-stdlib
 libqhull7
+libqt5charts5-dev
 libqt5concurrent5
 libqt5core5a
 libqt5dbus5
@@ -988,6 +989,8 @@ python3-yaml
 python-dev
 python-minimal
 python-talloc
+qt3d5-dev
+qt5-default
 qt5-gtk-platformtheme
 qt5-qmake
 qt5-qmake-bin
@@ -996,6 +999,7 @@ qtbase5-dev
 qtbase5-dev-tools
 qtchooser
 qtdeclarative5-dev
+qttools5-dev
 qttranslations5-l10n
 rake
 readline-common


### PR DESCRIPTION
These packages are required to build docs for [qt_core](https://crates.io/crates/qt_core) and [other Qt crates](https://crates.io/crates/qt_core/reverse_dependencies).