### PR TITLE
Add package dependencies for tesseract crates

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -479,6 +479,7 @@ libldap-2.4-2
 libldap-common
 libldb1
 liblept5
+libleptonica-dev
 libllvm6.0
 libllvm7
 libllvm8
@@ -788,6 +789,7 @@ libtbb2
 libtcl8.6
 libtdb1
 libtesseract4
+libtesseract-dev
 libtevent0
 libtext-charwidth-perl
 libtext-iconv-perl


### PR DESCRIPTION
This fixes the cargo build and doc generation for the following crates:

- tesseract - https://crates.io/crates/tesseract
- tesseract-sys - https://crates.io/crates/tesseract-sys
- leptonica-sys - https://crates.io/crates/leptonica-sys

