### PR TITLE
linux: add libpam0g-dev for crate pam-sys

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -597,6 +597,7 @@ libopusfile0
 liborc-0.4-0
 libp11-kit0
 libpam0g
+libpam0g-dev
 libpam-cap
 libpam-modules
 libpam-modules-bin


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/479