### PR TITLE
linux: install libelf-dev instead of libelf1

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -231,7 +231,7 @@ libegl1-mesa
 libegl1-mesa-dev
 libegl-mesa0
 libelektra-dev
-libelf1
+libelf-dev
 libenca0
 libenchant1c2a
 libencode-locale-perl


### PR DESCRIPTION
Needed to build my [libbpf-sys](https://github.com/alexforster/libbpf-sys) crate.