### PR TITLE
linux: add linux-headers-generic

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -985,6 +985,7 @@ libzmq5
 libzstd1
 libzvbi0
 libzvbi-common
+linux-headers-generic
 linux-libc-dev
 llvm
 nodejs


### PR DESCRIPTION
Needed to build my [libbpf-sys](https://github.com/alexforster/libbpf-sys) crate.