### PR TITLE
add packages for hyperscan, hyperscan-sys, grep-hyperscan to compile

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -405,6 +405,8 @@ libhunspell-dev
 libhwloc5
 libhwloc-plugins
 libhx509-5-heimdal
+libhyperscan4
+libhyperscan-dev
 libhyphen0
 libibus-1.0-5
 libibus-1.0-dev


### PR DESCRIPTION
This fixes the cargo doc generation for the following crates:

hyperscan - https://docs.rs/crate/hyperscan/0.1.8
hyperscan-sys - https://docs.rs/crate/hyperscan-sys/0.1.8
grep-hyperscan - https://docs.rs/crate/grep-hyperscan/0.0.1

Thanks !