### PR TITLE
Add bluetooth packages

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -5,6 +5,7 @@ automake
 autopoint
 autotools-dev
 binutils-arm-none-eabi
+bluetooth
 bsdmainutils
 build-essential
 bzip2
@@ -117,6 +118,7 @@ libblas3
 libblas-dev
 libblkid1
 libblkid-dev
+libbluetooth-dev
 libbluray2
 libbluray-dev
 libboost-filesystem1.62.0


### PR DESCRIPTION
[`bluetooth-sys`](https://crates.io/crates/bluetooth-sys) requires the bluetooth development libraries to be built.