### PR TITLE
Added gcc-multilib

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -24,6 +24,7 @@ docker.io
 dselect
 emacsen-common
 enchant
+gcc-multilib
 gfortran
 git
 gnupg


### PR DESCRIPTION
This fixes the `i686-unknown-linux-gnu` build for the winit docs.rs as mentioned in https://github.com/rust-windowing/winit/issues/1028#issuecomment-608649739 by @jyn514 