### PR TITLE
Add libldap2-dev

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -481,6 +481,7 @@ liblapack-dev
 liblcms2-2
 liblcms2-dev
 libldap-2.4-2
+libldap2-dev
 libldap-common
 libldb1
 liblept5


### PR DESCRIPTION
While both `libldap-2.4-2` and `libldap-common` are already contained, the relevant header files, in particular `/usr/include/ldap.h` live in the `ldap2-dev` package.