### PR TITLE
WIP: update to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 # Install the packages contained in `packages.txt`
 COPY packages.txt /opt/crates-build-env/packages.txt


### PR DESCRIPTION
This doesn't pass, apparently 20.04 got rid of a bunch of packages. We'll have to make a policy decision about whether we should get rid of outdated ones/look for a new version.

<details><summary>Missing packages:</summary>

Generated by copy pasting the errors from apt, then `"s/^E: Unable to locate package // ; s/E: Couldn't find any package by glob //; s/E: Couldn't find any package by regex //; s/E: Package '\([^']*\)' has no installation candidate/\1/" | tr -d "'" | sort -u`.

```
cpp-6
libapt-inst2.0
libapt-pkg5.0
libarmadillo8
libasan3
libavcodec57
libavformat57
libavresample3
libavutil55
libbind9-160
libboost-filesystem1.62.0
libboost-filesystem1.65.1
libboost-iostreams1.62.0
libboost-system1.62.0
libboost-system1.65.1
libcapnp-0.6.1
libcdio17
libcfitsio5
libcharls1
libcloog-isl4
libcsfml-audio2.4
libcsfml-graphics2.4
libcsfml-network2.4
libcsfml-system2.4
libcsfml-window2.4
libcwidget3v5
libdns1100
libdns-export1100
libdouble-conversion1
libelektra-dev
libevent-2.1-6
libevent-core-2.1-6
libevent-extra-2.1-6
libevent-openssl-2.1-6
libevent-pthreads-2.1-6
libexiv2-14
libffi6
libgcc-6-dev
libgdal20
libgdbm5
libgdcm2.8
libgeos-3.6.2
libgeotiff2
libgfortran3
libgfortran-6-dev
libglew2.0
libhdf5-100
libhdf5-openmpi-100
libhogweed4
libhttp-parser2.7.1
libhunspell-1.6-0
libhwloc5
libhyperscan4
libicu60
libiculx60
libilmbase12
libip4tc0
libirs160
libisc169
libisccc160
libisccfg160
libisc-export169
libisl15
libisl19
libiso9660-10
libjson-c3
libldb1
liblwres160
libmariadbclient18
libmysqlclient20
libnetcdf13
libnettle6
libntdb1
libobjc-6-dev
libogdi3.2
libopencv3.2-java
libopencv3.2-jni
libopencv-calib3d3.2
libopencv-contrib3.2
libopencv-core3.2
libopencv-features2d3.2
libopencv-flann3.2
libopencv-highgui3.2
libopencv-imgcodecs3.2
libopencv-imgproc3.2
libopencv-ml3.2
libopencv-objdetect3.2
libopencv-photo3.2
libopencv-shape3.2
libopencv-stitching3.2
libopencv-superres3.2
libopencv-video3.2
libopencv-videoio3.2
libopencv-videostab3.2
libopencv-viz3.2
libopenexr22
libopenmpi2
libperl5.26
libpolkit-backend-1-0
libpoppler73
libpostproc54
libprocps6
libproj12
libprotobuf10
libprotobuf-lite10
libprotoc10
libpython3.6-dev
libpython3.6-minimal
libpython3.6-stdlib
libpython-dev
libpython-stdlib
libreadline7
libruby2.5
libsane-extras
libsane-extras-common
libsensors4
libsfml-audio2.4
libsfml-graphics2.4
libsfml-network2.4
libsfml-system2.4
libsfml-window2.4
libsndio6.1
libssl1.0.0
libstdc++-6-dev
libswresample2
libswscale4
libv8-3.14.5
libvpx5
libwxgtk3.0-0v5
libx264-152
libx265-146
python-minimal
python-talloc
ruby2.5
vdpau-va-driver
```

</details>