### PR TITLE
Require packages.txt not to have duplicates

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 # Ensure packages lists are sorted
 for file in packages; do
-    cat "${file}.txt" | sort > "/tmp/sorted-${file}.txt"
+    cat "${file}.txt" | sort -u > "/tmp/sorted-${file}.txt"
     if ! diff -u "/tmp/sorted-${file}.txt" "${file}.txt"; then
         echo "Lint error: ${file}.txt is not sorted"
         exit 1


### PR DESCRIPTION
Example output for a duplicate `xxd` package:

```
--- /tmp/sorted-packages.txt	2020-05-01 14:21:41.785946286 -0400
+++ packages.txt	2020-05-01 14:20:24.102776791 -0400
@@ -1064,5 +1064,6 @@
 xserver-xorg-dev
 xtrans-dev
 xxd
+xxd
 xz-utils
 zlib1g-dev
Lint error: packages.txt is not sorted
```

r? @pietroalbini