### PR TITLE
Add libavdevice* and libavfilter*

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -103,6 +103,10 @@ libavahi-core7
 libavc1394-0
 libavcodec58
 libavcodec-dev
+libavdevice58
+libavdevice-dev
+libavfilter7
+libavfilter-dev
 libavformat58
 libavformat-dev
 libavresample4

--- a/packages.txt
+++ b/packages.txt
@@ -669,7 +669,6 @@ libpython3.8-minimal
 libpython3.8-stdlib
 libpython3-dev
 libpython3-stdlib
-libpython3-stdlib
 libpython-all-dev
 libqhull7
 libqt5charts5-dev
@@ -762,7 +761,6 @@ libsqlite3-dev
 libss2
 libssh2-1
 libssh-gcrypt-4
-libssl1.1
 libssl1.1
 libssl-dev
 libssl-doc


### PR DESCRIPTION
The added packages are required to build ffmpeg-sys-next and ffmpeg-next.

https://docs.rs/crate/ffmpeg-sys-next/4.2.0/builds/256836
https://docs.rs/crate/ffmpeg-next/4.2.1/builds/256842

Also added an unrelated commit to remove duplicates from the package list... Doesn't really belong to this PR but I was following the [guide](https://forge.rust-lang.org/docs-rs/add-dependencies.html) which asks me to satisfy linters, so please excuse me.