### PR TITLE
Add R languge base for libR-sys.

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1020,6 +1020,7 @@ qtchooser
 qtdeclarative5-dev
 qttools5-dev
 qttranslations5-l10n
+r-base-core
 rake
 re2c
 readline-common


### PR DESCRIPTION
The crate **libR-sys** is a **bindgen** wrapper for the R programming language. It has a dependency on **libR** which is contained in **r-base-core**.

I could not get the docker build to run and am therefore at the mercy of others to test this.

```$ docker-compose run -e DOCS_RS_LOCAL_DOCKER_IMAGE=build-env -v /home/andyt/extendr/libR-sys/:/opt/rustwide/workdir web build crate --local /opt/rustwide/workdir
Starting docsrs_db_1 ... error
Starting docsrs_s3_1 ... done

ERROR: for docsrs_db_1  Cannot start service db: driver failed programming external connectivity on endpoint docsrs_db_1 (726d83543d1101125b33782bece0f357c8536e180505d4c5bf3a2d2262b021cb): Error starting userland proxy: listen tcp 0.0.0.0:5432: bind: address already in use

ERROR: for db  Cannot start service db: driver failed programming external connectivity on endpoint docsrs_db_1 (726d83543d1101125b33782bece0f357c8536e180505d4c5bf3a2d2262b021cb): Error starting userland proxy: listen tcp 0.0.0.0:5432: bind: address already in use
```