### PR TITLE
Add libappindicator3-dev package for libappindicator-sys crate

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -61,6 +61,7 @@ liballegro-video5.2
 liballegro5-dev
 liballegro5.2
 libapparmor1
+libappindicator3-dev
 libapt-pkg-dev
 libapt-pkg6.0
 libarchive-cpio-perl


### PR DESCRIPTION
Package `libappindicator3-dev` is required by `libappindicator-sys` and as a result the `libappindicator` crate.

Fixes qdot/libappindicator-rs#10