### PR TITLE
add packages necessary for libcdio-sys to compile

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -445,6 +445,7 @@ libisccc161
 libisccfg163
 libisl22
 libiso9660-11
+libiso9660-dev
 libitm1
 libjack-jackd2-0
 libjansson4


### PR DESCRIPTION
Added the `libiso9660-dev` package, which contains the necessary headers for `libcdio-sys`.