### PR TITLE
Add libmilter-dev for milter-sys

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -512,6 +512,7 @@ libmail-sendmail-perl
 libmailtools-perl
 libmariadbclient-dev
 libmariadbclient-dev-compat
+libmilter-dev
 libminizip1
 libmirclient-dev
 libmirclient9


### PR DESCRIPTION
This adds package libmilter-dev for the milter-sys crate.

Thank you!