### PR TITLE
add packages necessary for pcap and hassh to compile

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -619,6 +619,7 @@ libparse-debianchangelog-perl
 libparted-dev
 libparted-fs-resize0
 libparted2
+libpcap-dev
 libpciaccess-dev
 libpciaccess0
 libpcre16-3


### PR DESCRIPTION
The [hassh](https://crates.io/crates/hassh) crate depends on the [pcap](https://crates.io/crates/pcap) crate which need `libpcap-dev` package to compile.