### PR TITLE
add package necessary for lxc-sys to compile

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -501,6 +501,7 @@ liblua5.3-dev
 liblwp-mediatypes-perl
 liblwp-protocol-https-perl
 liblwres161
+liblxc-dev
 liblz4-1
 liblzma-dev
 liblzma5


### PR DESCRIPTION
https://docs.rs/crate/lxc-sys/0.2.1/builds/232365

I try to build the documentation on my computer, it seems ok, but I can’t display the documentation.