### PR TITLE
Add librtmidi-dev for rtmidi

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -709,6 +709,7 @@ libroken18-heimdal
 librsvg2-2
 librsvg2-common
 librsvg2-dev
+librtmidi-dev
 librtmp1
 librubberband2
 libruby2.7


### PR DESCRIPTION
Adds the `librtmidi-dev` package which is necessary for the [rtmidi](https://crates.io/crates/rtmidi) crate to build.

Note that this won't fix the rtmidi docs build until I publish the next version of rtmidi which supports v3.0.0 of the library (which is what Ubuntu Focal provides). Once this PR is merged I'll publish so the docs will (hopefully) build.