### PR TITLE
add packages necessary for erfa-sys to compile

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -245,6 +245,7 @@ libencode-locale-perl
 libepoxy-dev
 libepoxy0
 libepsilon1
+liberfa-dev
 liberror-perl
 libestr0
 libev-dev


### PR DESCRIPTION
Hi!  This commit adds an astronomy library, mostly used for coordinate transformations.  The relevant erfa-sys package is [here](https://github.com/cjordan/rust-erfa).  I've been able to compile on docs.rs by using a static feature and the local C compiler, but with this request, maybe some pain is spared in the future.  Happy to answer any questions!  And thanks.