### PR TITLE
Add packages necessary for lldb-sys to compile.

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -492,6 +492,7 @@ libldap2-dev
 libldb2
 liblept5
 libleptonica-dev
+liblldb-dev
 libllvm6.0
 libllvm7
 libllvm8


### PR DESCRIPTION
This is necessary for `lldb-sys` to compile (and subsequently, `lldb`).