### PR TITLE
Add packages necessary for libayatana-appindicator-sys to compile.

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -115,6 +115,7 @@ libavresample-dev
 libavresample4
 libavutil-dev
 libavutil56
+libayatana-appindicator3-dev
 libbdplus0
 libbind-dev
 libbind9-161


### PR DESCRIPTION
**Packages added:**
* libayatana-appindicator3-dev

**Fixes compilation of:**
* libayatana-appindicator-sys