### PR TITLE
install libvpx-dev

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -850,6 +850,7 @@ libvorbis-dev
 libvorbis0a
 libvorbisenc2
 libvorbisfile3
+libvpx-dev
 libvpx6
 libvtk6.3
 libwacom-bin


### PR DESCRIPTION
Fixes #82. This is necessary for crates `libvpx-native-sys`, `env-libvpx-sys`, `vpx-encode`, `encode-webm-video-frames`.