### PR TITLE
Add packages necessary for ki18n-rs to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -477,6 +477,7 @@ libkadm5clnt-mit11
 libkadm5srv-mit11
 libkdb5-9
 libkeyutils1
+libkf5i18n-dev
 libklibc
 libkmlbase1
 libkmldom1


### PR DESCRIPTION
Added Package: libkf5i18n-dev
This is needed for [ki18n-rs](https://crates.io/crates/ki18n-rs) to compile and build documentation in docrs.