### PR TITLE
Add llvm-12

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -1011,6 +1011,7 @@ libzvbi0
 linux-headers-generic
 linux-libc-dev
 llvm
+llvm-12
 lxc-dev
 mpich
 musl-tools


### PR DESCRIPTION
This is needed by the latest version of wasmer which bumped the minimum LLVM version to 12: https://docs.rs/crate/wasmer/2.1.0