### PR TITLE
Add packages necessary for compiled-nn-bindings to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -399,6 +399,7 @@ libharfbuzz0b
 libhcrypto4-heimdal
 libhdf4-0-alt
 libhdf5-103
+libhdf5-dev
 libhdf5-openmpi-103
 libheimbase1-heimdal
 libheimntlm0-heimdal


### PR DESCRIPTION
This PR adds `libhdf5-dev` to the build environment to make the crate `compiled-nn-bindings` compile. Latest build failure: https://docs.rs/crate/compiled-nn-bindings/0.1.0/builds/479931