### PR TITLE
Update to Python 3.9

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -692,10 +692,10 @@ libpython2.7-minimal
 libpython2.7-stdlib
 libpython3-dev
 libpython3-stdlib
-libpython3.8
-libpython3.8-dev
-libpython3.8-minimal
-libpython3.8-stdlib
+libpython3.10
+libpython3.10-dev
+libpython3.10-minimal
+libpython3.10-stdlib
 libqhull7
 libqt5charts5-dev
 libqt5concurrent5

--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -692,10 +692,10 @@ libpython2.7-minimal
 libpython2.7-stdlib
 libpython3-dev
 libpython3-stdlib
-libpython3.10
-libpython3.10-dev
-libpython3.10-minimal
-libpython3.10-stdlib
+libpython3.9
+libpython3.9-dev
+libpython3.9-minimal
+libpython3.9-stdlib
 libqhull7
 libqt5charts5-dev
 libqt5concurrent5


### PR DESCRIPTION
This allows PyO3 (and other crates) to use Python 3.10 features.

See also https://github.com/PyO3/pyo3/issues/2426