### PR TITLE
add package necessary for libreoffice-rs to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -723,6 +723,7 @@ librdmacm-dev
 librdmacm1
 libreadline-dev
 libreadline8
+libreofficekit-dev
 librest-0.7-0
 librhash0
 libroken18-heimdal


### PR DESCRIPTION
As a LibreOfficeKit binding, libreoffice-rs needs those headers