### PR TITLE
add package necessary for libbtrfsutil to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -137,6 +137,7 @@ libboost-system1.71.0
 libbrotli1
 libbs2b0
 libbsd0
+libbtrfsutil-dev
 libbz2-1.0
 libbz2-dev
 libc-ares-dev


### PR DESCRIPTION
Add `libbtrfsutil-dev` to fix the following 2 crates:
https://docs.rs/crate/libbtrfsutil/latest
https://docs.rs/crate/libbtrfsutil-sys/latest

It would also be nice to re-queue these two packages afterwards if this gets merged. Thanks!