### PR TITLE
add packages necessary for ipset-sys to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -449,6 +449,7 @@ libio-html-perl
 libio-socket-ssl-perl
 libio-string-perl
 libip4tc2
+libipset-dev
 libirs161
 libisc-export1105
 libisc1105


### PR DESCRIPTION
hi - I need `libipset-dev` in order to build the docs for [ipset-sys](https://github.com/pldubouilh/ipset-sys) ([docs.rs](https://docs.rs/crate/ipset-sys/latest))
thank you !