### PR TITLE
add package necessary for wxrust to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -901,6 +901,7 @@ libwww-perl
 libwww-robotrules-perl
 libwxbase3.0-0v5
 libwxgtk3.0-gtk3-0v5
+libwxgtk3.0-gtk3-dev
 libx11-6
 libx11-data
 libx11-dev


### PR DESCRIPTION
Following two crates require `wx-config` and build deps to compile.
- [wxrust](https://docs.rs/crate/wxrust/latest)
- [wxrust-base](https://docs.rs/crate/wxrust-base/latest)

Please add this. Thanks in advance.