### PR TITLE
add packages necessary for mdbsql to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -1026,6 +1026,7 @@ linux-libc-dev
 llvm
 llvm-12
 lxc-dev
+mdbtools-dev
 mpich
 musl-tools
 nasm


### PR DESCRIPTION
The mdbsql is a binding package of libmdbsql, which is part of mdbtools, provide a SQL engine wrapper in Rust.