### PR TITLE
Add mosquitto-dev package for mosquitto-plugin

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -1027,6 +1027,7 @@ llvm
 llvm-12
 lxc-dev
 mdbtools-dev
+mosquitto-dev
 mpich
 musl-tools
 nasm


### PR DESCRIPTION
The mosquitto-plugin crates needs the mosquitto_broker.h header as bindgen input.

This fixes [#18](https://github.com/TotalKrill/mosquitto_plugin/issues/18).