### PR TITLE
add packages necessary for xcb-util-cursor-sys to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -917,6 +917,7 @@ libxau-dev
 libxau6
 libxaw7
 libxaw7-dev
+libxcb-cursor-dev
 libxcb-dri2-0
 libxcb-dri2-0-dev
 libxcb-dri3-0


### PR DESCRIPTION
add: libxcb-cursor-dev package