### PR TITLE
Add meson to included packages

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -1030,6 +1030,7 @@ llvm
 llvm-12
 lxc-dev
 mdbtools-dev
+meson
 mosquitto-dev
 mpich
 musl-tools


### PR DESCRIPTION
Adding meson to included packages so that documentation is generated for the following crates
`libvmaf-sys`  
`libvmaf-rs`