### PR TITLE
Add `libc++-dev` package to linux environment

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -132,6 +132,7 @@ libbsd0
 libbtrfsutil-dev
 libbz2-1.0
 libbz2-dev
+libc++-dev
 libc-ares-dev
 libc-ares2
 libc-bin


### PR DESCRIPTION
We're using `libc++` (clang's C++ standard library) instead of `libstdc++` for [yoga-rs](https://github.com/bschwind/yoga-rs) because using `libstdc++` / using whatever is set as default was causing bindgen to generate code that wouldn't compile.

However, this dependency is missing in the build environment which is causing building docs for `docs.rs` to fail (https://github.com/rust-lang/docs.rs/issues/2017)