### PR TITLE
Update ubuntu version in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing-linux-packages.md
+++ b/.github/ISSUE_TEMPLATE/missing-linux-packages.md
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 <!-- Thanks for reporting this issue!
-     Please remember our build environment is based on Ubuntu 20.04 LTS,
+     Please remember our build environment is based on Ubuntu 22.04 LTS,
      so the packages you're requesting need to be available in its
      repositories. -->
 
 **Affected crates:** foo, foo-sys
-**Ubuntu 20.04 packages to install:** libfoo-dev
+**Ubuntu 22.04 packages to install:** libfoo-dev


### PR DESCRIPTION
It looks like the ubuntu version was recently changed from 20.04 to 22.04 in #120, but the issue template was never updated.