### PR TITLE
Add binutils-mingw-w64-x86-64 to linux environment

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -5,6 +5,7 @@ automake
 autopoint
 autotools-dev
 binutils-arm-none-eabi
+binutils-mingw-w64-x86-64
 bison
 bluetooth
 bsdmainutils


### PR DESCRIPTION
This installs `x86_64-w64-mingw32-windmc` and `x86_64-w64-mingw32-windres` which are required to build https://github.com/bbqsrc/eventlog (see failing build at https://docs.rs/crate/eventlog/0.2.2/builds/747288)

Fixes https://github.com/bbqsrc/eventlog/issues/4