### PR TITLE
Add libext2fs-dev to list of packages

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -253,6 +253,7 @@ libexiv2-27
 libexiv2-dev
 libexpat1
 libexpat1-dev
+libext2fs-dev
 libext2fs2
 libfabric1
 libfakeroot


### PR DESCRIPTION
This is required by e2p-sys and its dependent e2p-fileflags.