### PR TITLE
add packages necessary for openslide-sys to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -600,6 +600,7 @@ libopengl0
 libopenjp2-7
 libopenmpi3
 libopenmpt0
+libopenslide-dev
 libopus-dev
 libopus0
 libopusfile0


### PR DESCRIPTION
Hello, 

In order to release the next major release of [openslide-sys](https://github.com/AzHicham/openslide-sys), I need libopenslide-dev to be installed :) 

Thank you 