### PR TITLE
Add packages for libtracecmd

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -818,6 +818,9 @@ libtinfo5
 libtk8.6
 libtool
 libtool-bin
+libtracecmd-dev
+libtraceevent-dev
+libtracefs-dev
 libtry-tiny-perl
 libtsan0
 libtwolame0


### PR DESCRIPTION
To build [libtracecmd](https://github.com/google/libtracecmd-rs), I'd like to add the following packages:

* libtracecmd-dev
* libtraceevent-dev
* libtracefs-dev

Thanks!