### PR TITLE
Add package for libfprint-rs

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -276,6 +276,7 @@ libfontconfig1
 libfontconfig1-dev
 libfontenc-dev
 libfontenc1
+libfprint-2-dev
 libfreetype6
 libfreetype6-dev
 libfreexl1


### PR DESCRIPTION
To build [libfprint-rs](https://github.com/AlvaroParker/libfprint-rs), I'd like to add the following packages:
* libfprint-2-dev

Thanks!