### PR TITLE
Install libtdb-dev (needed for trivialdb crate)

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -800,6 +800,7 @@ libtalloc2
 libtasn1-6
 libtbb2
 libtcl8.6
+libtdb-dev
 libtdb1
 libtesseract-dev
 libtesseract4


### PR DESCRIPTION
Install libtdb-dev (needed for trivialdb crate)

Fixes https://github.com/rust-lang/crates-build-env/issues/132
