### PR TITLE
Add liblz4-dev, libsnappy-dev, libzstd-dev

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -505,6 +505,7 @@ liblwp-protocol-https-perl
 liblwres161
 liblxc1
 liblz4-1
+liblz4-dev
 liblzma-dev
 liblzma5
 liblzo2-2
@@ -753,6 +754,7 @@ libsm6
 libsmartcols1
 libsmbclient
 libsmbclient-dev
+libsnappy-dev
 libsnappy1v5
 libsndfile1
 libsndio-dev
@@ -1004,6 +1006,7 @@ libyaml-0-2
 libzfslinux-dev
 libzmq3-dev
 libzmq5
+libzstd-dev
 libzstd1
 libzvbi-common
 libzvbi0


### PR DESCRIPTION
They are needed to compile 'orcxx' and 'orcxx_derive': https://docs.rs/crate/orcxx/0.1.0/builds/880112

Thanks!