### PR TITLE
Add libprotoc-dev

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -660,6 +660,7 @@ libproj22
 libprotobuf-dev
 libprotobuf-lite23
 libprotobuf23
+libprotoc-dev
 libprotoc23
 libprotozero-dev
 libproxy1v5


### PR DESCRIPTION
It is also needed to build orcxx. Sorry, I missed it when writing #134