### PR TITLE
Add lld and wasi-libc for building C to WASI

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -1013,6 +1013,7 @@ libzvbi-common
 libzvbi0
 linux-headers-generic
 linux-libc-dev
+lld
 llvm
 llvm-12
 lxc-dev
@@ -1082,6 +1083,7 @@ udev
 uuid-dev
 va-driver-all
 vdpau-driver-all
+wasi-libc
 wget
 xbitmaps
 xorg-dev


### PR DESCRIPTION
Building a WASI module from C source code requires a WASI libc implementation provided by the `wasi-libc` package and the `wasm-ld` linker provided by the `lld` package.