### PR TITLE
add packages necessary for yices2-sys to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -29,6 +29,7 @@ gfortran
 git
 gnupg
 golang
+gperf
 graphicsmagick
 gstreamer1.0-plugins-base
 gstreamer1.0-plugins-good


### PR DESCRIPTION
Adds gperf tool required to build the Yices2 SMT solver library bound by the yices2-sys bindings crate.