### PR TITLE
Add `libchafa-dev` package to linux environment

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -170,6 +170,7 @@ libcfitsio-doc
 libcfitsio9
 libcgi-fast-perl
 libcgi-pm-perl
+libchafa-dev
 libcharls2
 libchewing3-dev
 libchromaprint1


### PR DESCRIPTION
`chafa-sys` rust package which is just ffi bindings to [chafa](https://hpjansson.org/chafa/) expects `libchafa-dev` to be installed.