### PR TITLE
Add libmodsecurity-dev to packages.txt

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -532,6 +532,7 @@ libmircore-dev
 libmircore1
 libmnl0
 libmodplug1
+libmodsecurity-dev
 libmount1
 libmp3lame0
 libmpc3


### PR DESCRIPTION
Adds `libmodsecurity-dev` in order to build [rust-modsecurity](https://github.com/rkrishn7/rust-modsecurity)