### PR TITLE
Add llvm-15-dev package for cir crate

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -1024,6 +1024,7 @@ linux-libc-dev
 lld
 llvm
 llvm-12
+llvm-15-dev
 lxc-dev
 mdbtools-dev
 meson


### PR DESCRIPTION
The cir crate uses the llvm libraries in order to build BPF IR decoders. llvm 15 or later is required.