### PR TITLE
Add libxapian-dev so xapian-rs can be compiled

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -909,6 +909,7 @@ libx264-163
 libx264-dev
 libx265-199
 libx265-dev
+libxapian-dev
 libxapian30
 libxau-dev
 libxau6


### PR DESCRIPTION
This commit adds `libxapian-dev` to the build environment, which allows [`xapian-rs`](https://github.com/torrancew/xapian-rs)  to compile successfully.

Here's a previous (failed) build for `xapian-rs`: https://docs.rs/crate/xapian-rs/0.1.0/builds/1286762

This change was tested using the [published workflow](https://forge.rust-lang.org/docs-rs/add-dependencies.html). All lints pass and `xapian-rs` now compiles successfully in the docker environment.