### PR TITLE
Add `libadwaita-1-dev` and `libgtk-4-dev`

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -41,6 +41,7 @@ lib32stdc++6
 libaa1
 libaacs0
 libacl1
+libadwaita-1-dev
 libaec0
 libalgorithm-diff-perl
 libalgorithm-diff-xs-perl
@@ -378,6 +379,7 @@ libgtk-3-0
 libgtk-3-bin
 libgtk-3-common
 libgtk-3-dev
+libgtk-4-dev
 libgtk2.0-0
 libgtk2.0-bin
 libgtk2.0-common


### PR DESCRIPTION
### Fixes #152 

This adds `libadwaita-1-dev` and `libgtk-4-dev`, which should enable building GTK4-based crates (such as `nuit`).