### PR TITLE
fix docker push permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,13 @@ on:
       - master
   pull_request: {}
 
-concurrency: 
+concurrency:
   group: ${{ format('{0}/{1}', github.repository_owner, github.ref) }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   lint:
@@ -45,7 +49,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
 


### PR DESCRIPTION
Based on https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages 

I had difficulties testing this from my fork, so let's just merge it and see if it works on the main branch. 