### PR TITLE
Revert "Add libbladerf-dev to linux packages"

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -121,7 +121,6 @@ libbdplus0
 libbind-dev
 libbind9-161
 libbinutils
-libbladerf-dev
 libblas-dev
 libblas3
 libblkid-dev


### PR DESCRIPTION
Reverts rust-lang/crates-build-env#156