### PR TITLE
add packages necessary for rsfdisk-sys to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -266,6 +266,7 @@ libfabric1
 libfakeroot
 libfastjson4
 libfcgi-perl
+libfdisk-dev
 libfdisk1
 libffi-dev
 libffi7


### PR DESCRIPTION
Added `libfdisk-dev` to fix the build failure of [`rsfdisk-sys`](https://docs.rs/crate/rsfdisk-sys/latest). `pkg-config` could not find the necessary header files to build this FFI crate.