### PR TITLE
add packages necessary for containerd-shim-wasm to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -740,6 +740,7 @@ libsasl2-modules-db
 libsctp1
 libsdl2-2.0-0
 libsdl2-dev
+libseccomp-dev
 libseccomp2
 libsecret-1-0
 libsecret-common


### PR DESCRIPTION
Added the missing `libseccomp-dev` package so that [containerd-shim-wasm](https://crates.io/crates/containerd-shim-wasm) can build.

Related build failure: https://docs.rs/crate/containerd-shim-wasm/0.7.0/builds/1383467
