### PR TITLE
add packages necessary for rgrit-sys to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -285,6 +285,7 @@ libfontconfig1-dev
 libfontenc-dev
 libfontenc1
 libfprint-2-dev
+libfreeimage-dev
 libfreetype6
 libfreetype6-dev
 libfreexl1


### PR DESCRIPTION
This PR adds `libfreeimage-dev` to fix [`rgrit-sys`](https://docs.rs/crate/rgrit-sys/latest).