### PR TITLE
Add packages necessary for ipopt-sys to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -14,6 +14,7 @@ bzip2
 capnproto
 clang
 cmake
+coinor-libipopt-dev
 comerr-dev
 cpp
 cpp-10


### PR DESCRIPTION
Hi, new here, but I followed the steps on forge.

This adds the packages required for the IPOPT optimization software which is used in [`ipopt-sys`](https://docs.rs/crate/ipopt-sys/0.6.0). 

Can you also rerun the build for the dependents:
- https://docs.rs/crate/ipopt/latest
- https://docs.rs/crate/ipopt-ad/latest

Thank you!