### PR TITLE
add libdlt-dev to linux packages

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -214,6 +214,7 @@ libdeflate-dev
 libdevmapper-dev
 libdevmapper-event1.02.1
 libdevmapper1.02.1
+libdlt-dev
 libdmx-dev
 libdmx1
 libdns-export1110


### PR DESCRIPTION
libdlt-dev contains the development libraries for the Diagnostic Log and Trace (DLT) system.

It is required for crates
- dlt-tracing-subscriber
- dlt_log
- libdlt-sys
