### PR TITLE
fix: use `latest` as the label for master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/${{ matrix.image }}
+          tags: latest
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Fix the issue where `latest` label not applied to the master branch.
(`latest` label only apply to tags by default)