### PR TITLE
add packages necessary for vizoxide / graphviz-sys to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -370,6 +370,7 @@ libgraphene-1.0-0
 libgraphicsmagick1-dev
 libgraphite2-3
 libgraphite2-dev
+libgraphviz-dev
 libgsm1
 libgssapi-krb5-2
 libgssapi3-heimdal


### PR DESCRIPTION
[vizoxide](https://crates.io/crates/vizoxide) uses [graphviz-sys](https://crates.io/crates/graphviz-sys) to provide an ergonomic wrapper for GraphViz. Both packages are mine. I'd like to have this added so that vizoxide can have a documentation.