### PR TITLE
Add libsoup-3.0-dev to Linux environment

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -780,6 +780,7 @@ libsodium-dev
 libsodium23
 libsoup-2.4-1
 libsoup-3.0-0
+libsoup-3.0-dev
 libsoup-gnome-2.4-1
 libsoup2.4-dev
 libsoxr0


### PR DESCRIPTION
https://docs.rs/crate/tauri-plugin-desktop-underlay/0.1.0/builds/2099704/x86_64-unknown-linux-gnu.txt

`webkit2gtk` needs `soup3`, which needs `soup3-sys`, which invokes `pkg-config --libs --cflags libsoup-3.0 'libsoup-3.0 >= 3.0'`. Current environment only has `libsoup-3.0-0` but no headers.