### PR TITLE
Add libwebkit2gtk-4.1-dev to Linux environment

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -896,6 +896,7 @@ libwayland-egl1
 libwayland-server0
 libwbclient0
 libwebkit2gtk-4.1-0
+libwebkit2gtk-4.1-dev
 libwebp-dev
 libwebp7
 libwebpdemux2


### PR DESCRIPTION
https://docs.rs/crate/tauri-plugin-desktop-underlay/0.1.1/builds/2101971/x86_64-unknown-linux-gnu.txt

`webkit2gtk` needs `webkit2gtk-sys`, which invokes `pkg-config --libs --cflags webkit2gtk-4.1 'webkit2gtk-4.1 >= 2.40'`. Current environment only has `webkit2gtk-4.1-0` but no headers.

Sorry for a separate PR from #172, I didn't realize at that time that I was missing more dependencies. And is it possible to trigger a rebuild on `tauri-plugin-desktop-underlay 0.1.1` after this dependency is added? Thanks in advance!