### PR TITLE
Add libostree-dev to Linux environment

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -612,6 +612,7 @@ libopus-dev
 libopus0
 libopusfile0
 liborc-0.4-0t64
+libostree-dev
 libp11-kit0
 libpam-cap
 libpam-modules


### PR DESCRIPTION
Resolves: https://github.com/ostreedev/ostree/issues/3441
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
