### PR TITLE
Add sqlite3 package to make the sqlite3 executable available in Linux

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -1094,6 +1094,7 @@ rubygems-integration
 samba-libs
 sane-utils
 sgml-base
+sqlite3
 sudo
 tcl
 tcl8.6


### PR DESCRIPTION
The sqlite3 executable (CLI) is called in the process of [building PROJ] on which grib crate indirectly depends.

Closes: noritada/grib-rs#124

[building PROJ]: https://proj.org/en/stable/install.html