### PR TITLE
Add libcups2-dev for CUPS library bindings

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -192,6 +192,7 @@ libcsfml-graphics2.6
 libcsfml-network2.6
 libcsfml-system2.6
 libcsfml-window2.6
+libcups2-dev
 libcups2t64
 libcurl3t64-gnutls
 libcurl4t64


### PR DESCRIPTION
we are using libcups2-dev for [cups.rs](https://docs.rs/crate/cups_rs/0.1.0), [build](https://docs.rs/crate/cups_rs/0.1.0/builds/1966736/x86_64-unknown-linux-gnu.txt)