### PR TITLE
add packages necessary for xkb-evdev-trans to compile

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -980,6 +980,7 @@ libxinerama-dev
 libxinerama1
 libxkbcommon-dev
 libxkbcommon-x11-0
+libxkbcommon-x11-dev
 libxkbcommon0
 libxkbfile-dev
 libxkbfile1


### PR DESCRIPTION
added libxkbcommon-x11-dev to packages in order to compile documentation for xkb-evdev-trans