### PR TITLE
Add libsubid-dev

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -806,6 +806,7 @@ libstdc++-14-dev
 libstdc++-arm-none-eabi-newlib
 libstdc++6
 libsub-name-perl
+libsubid-dev
 libsuitesparse-dev
 libsuperlu6
 libsvm-dev


### PR DESCRIPTION
This is needed for [the `subid-sys` crate](https://crates.io/crates/subid-sys).

Package added: `libsubid-dev`.