### PR TITLE
Add libopusenc-dev to linux environment

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -611,6 +611,7 @@ libopenmpt0t64
 libopenslide-dev
 libopus-dev
 libopus0
+libopusenc-dev
 libopusfile0
 liborc-0.4-0t64
 libostree-dev


### PR DESCRIPTION
This is needed for [the `opusenc-sys` crate](https://crates.io/crates/opusenc-sys).
> 
Package added: `libopusenc-dev`.

