### PR TITLE
Add librpm-dev to linux environment

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -745,6 +745,7 @@ librest-1.0-0
 librhash0
 librlottie-dev
 libroken19t64-heimdal
+librpm-dev
 librsvg2-2
 librsvg2-common
 librsvg2-dev


### PR DESCRIPTION
Adding so that https://github.com/rpm-software-management/librpm.rs/ will be able to build docs for future releases.