### PR TITLE
linux: add libc++-dev packages

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -142,6 +142,8 @@ libbsd0
 libbtrfsutil-dev
 libbz2-1.0
 libbz2-dev
+libc++-dev
+libc++abi-dev
 libc-ares-dev
 libc-bin
 libc-dev-bin


### PR DESCRIPTION
Fixes #125 

also looked at the [build error of the mentioned crate](https://docs.rs/crate/freesasa-sys/0.1.12/builds/1186261)