### PR TITLE
Add libradare2-dev to packages list

### DIFF
--- a/linux/packages.txt
+++ b/linux/packages.txt
@@ -721,6 +721,7 @@ libqt6svgwidgets6
 libqt6test6
 libqt6xml6
 libquadmath0
+libradare2-dev
 libraw1394-11
 librdmacm-dev
 librdmacm1t64


### PR DESCRIPTION
Add `libradare2-dev` to `linux/packages.txt` so the documentations of radare2 crate can be built.

- [x] Confirmed `libradare2-dev` is available in the Ubuntu 26.04 archives.
- [x] Verified the `linux` Docker image builds successfully with the updated packages list